### PR TITLE
migrate sphinx mathjax from jsdelivr to cdnjs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -60,3 +60,4 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
 latex_engine = 'xelatex'
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-mml-chtml.min.js'


### PR DESCRIPTION
jsdelivr, which is the default mathjax path in the sphinx, has been blocked in China. See jsdelivr/jsdelivr#18392. We need to drop jsdelivr to make our equations still shown in China.