### PR TITLE
set the current site as Tutorials

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 myst_parser
-deepmodeling_sphinx
+deepmodeling_sphinx >= 0.0.11
 sphinx_rtd_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -61,3 +61,4 @@ html_static_path = ['_static']
 
 latex_engine = 'xelatex'
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-mml-chtml.min.js'
+deepmodeling_current_site = 'Tutorials'


### PR DESCRIPTION
A new config is added to `deepmodeling_sphinx` where one can assign the current site and show the blue circle icon:
![image](https://user-images.githubusercontent.com/9496702/176836862-13b7f68a-aa79-40f7-bb70-9e6f793794ac.png)

![image](https://user-images.githubusercontent.com/9496702/176837296-d2c81706-b1c7-4477-a5e6-8c7e7604918b.png)
